### PR TITLE
Implementation of edu-sharing-repo in moodle 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vagrant
+.history

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Dieses Projekt bietet die Möglichkeit, ein moodle mit minimalem Aufwand in einer virtuellen Maschine aufzusetzen. Voraussetzung ist die Installation von
 [Git](https://git-scm.com/downloads),  [Vagrant](https://www.vagrantup.com/downloads.html) und [VirtualBox](https://www.virtualbox.org/wiki/Downloads).
 
+Außerdem kann die Moodle-Instanz mit einem edu-sharing Repositorium verbunden werden. Siehe hierfür [Edu-Sharing-Integration](#edu-sharing-integration).
+
 ## Installation
 
 Soll die moodle-box mit edu-sharing verknüpft werden, dann im Vagrantfile den Eintrag "ansible.skip_tags = [ "edu-sharing-plugin" ]" entfernen/einkommentieren.
@@ -52,3 +54,12 @@ vagrant ssh
 
 * Einloggen als Administrator
 * Website-Administration > Mobile App > Mobile Einstellungen > Webservice für mobile Endgeräte aktivieren
+
+## Edu-Sharing-Integration
+
+- zunächst Edu-Sharing-Box wie in [Installation](https://github.com/TIBHannover/edu-sharing-box) geschildert installieren
+- falls die Moodle-Box bereits installiert wurde, im Vagrantfile den Eintrag `ansible.skip_tags = [ "edu-sharing-plugin" ]` auskommentieren, damit die nötigen Plugins installiert werden können
+- im moodle-box Verzeichnis den Befehl `vagrant reload --provision` ausführen
+- anschließend im Vagrantfile der Edu-Sharing-Box die Auskommentierung von `ansible.skip_tags = [ "moodle-registration" ]` entfernen
+- im edu-sharing-box-Verzeichnis den Befehl `vagrant reload --provision`ausführen
+- nun sollte in moodle eine Einbindung des edu-sharing Repositoriums erfolgt sein

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ vagrant ssh
 
 - zunächst Edu-Sharing-Box wie in [Installation](https://github.com/TIBHannover/edu-sharing-box) geschildert installieren
 - falls die Moodle-Box bereits installiert wurde, im Vagrantfile den Eintrag `ansible.skip_tags = [ "edu-sharing-plugin" ]` auskommentieren, damit die nötigen Plugins installiert werden können
+- falls die Edu-Sharing Version v4.2 installiert wurde in group_vars/all.yml `edusharing_plugin_url` und `edusharing_plugin_dir` entsprechend anpassen
 - im moodle-box Verzeichnis den Befehl `vagrant reload --provision` ausführen
 - anschließend im Vagrantfile der Edu-Sharing-Box die Auskommentierung von `ansible.skip_tags = [ "moodle-registration" ]` entfernen
 - im edu-sharing-box-Verzeichnis den Befehl `vagrant reload --provision`ausführen

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,7 +20,7 @@ Vagrant.configure("2") do |config|
     ansible.install = true
     ansible.install_mode = "pip"
     # Vagrant 2.2.5: fix pip installation by uncommenting the next line (see https://github.com/hashicorp/vagrant/issues/10950)
-    #ansible.pip_install_cmd = "curl https://bootstrap.pypa.io/get-pip.py | sudo python"
+    # ansible.pip_install_cmd = "curl https://bootstrap.pypa.io/get-pip.py | sudo python"
     ansible.version = "latest"
 #  config.vm.provision "ansible" do |ansible|
     ansible.compatibility_mode = "2.0"

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -20,4 +20,9 @@ moodle_db:
   user: moodle
   password: moodle
 
+edu_sharing_host: 192.168.98.101
+edu_sharing_base_domain: http://192.168.98.101
+edu_sharing_url: "{{ edu_sharing_base_domain }}/edu-sharing"
 edusharing_plugin_url: https://github.com/edu-sharing/plugin-moodle/archive/4.1.2.tar.gz
+
+base_dir: "{{ansible_env.HOME}}"

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -3,6 +3,7 @@ moodle_host: 192.168.98.105
 moodle_url: "http://{{moodle_host}}"
 moodle_archive_url: https://download.moodle.org/download.php/direct/stable37/moodle-3.7.tgz
 download_dir: /home/vagrant
+edu_sharing_plugin_dir: "{{ download_dir }}/plugin-moodle-4.2"
 moodle_data_dir: /var/moodledata
 moodle_root_dir: /var/www
 
@@ -23,6 +24,6 @@ moodle_db:
 edu_sharing_host: 192.168.98.101
 edu_sharing_base_domain: http://192.168.98.101
 edu_sharing_url: "{{ edu_sharing_base_domain }}/edu-sharing"
-edusharing_plugin_url: https://github.com/edu-sharing/plugin-moodle/archive/4.1.2.tar.gz
+edusharing_plugin_url: https://github.com/edu-sharing/plugin-moodle/archive/4.2.tar.gz
 
 base_dir: "{{ansible_env.HOME}}"

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -3,7 +3,10 @@ moodle_host: 192.168.98.105
 moodle_url: "http://{{moodle_host}}"
 moodle_archive_url: https://download.moodle.org/download.php/direct/stable37/moodle-3.7.tgz
 download_dir: /home/vagrant
-edu_sharing_plugin_dir: "{{ download_dir }}/plugin-moodle-4.2"
+
+# bei Benutzung von edu-sharing v4.2 bitte entsprechend das plugin 4.2 benutzen
+edu_sharing_plugin_dir: "{{ download_dir }}/plugin-moodle-4.1.2"
+# edu_sharing_plugin_dir: "{{ download_dir }}/plugin-moodle-4.2"
 moodle_data_dir: /var/moodledata
 moodle_root_dir: /var/www
 
@@ -24,6 +27,9 @@ moodle_db:
 edu_sharing_host: 192.168.98.101
 edu_sharing_base_domain: http://192.168.98.101
 edu_sharing_url: "{{ edu_sharing_base_domain }}/edu-sharing"
-edusharing_plugin_url: https://github.com/edu-sharing/plugin-moodle/archive/4.2.tar.gz
+
+# bei Benutzung von edu-sharing v4.2 bitte die das Plugin v4.2 benutzen
+edusharing_plugin_url: https://github.com/edu-sharing/plugin-moodle/archive/4.1.2.tar.gz
+# edusharing_plugin_url: https://github.com/edu-sharing/plugin-moodle/archive/4.2.tar.gz
 
 base_dir: "{{ansible_env.HOME}}"

--- a/ansible/roles/edu-sharing-plugin/tasks/main.yml
+++ b/ansible/roles/edu-sharing-plugin/tasks/main.yml
@@ -27,7 +27,6 @@
     url: "{{ edusharing_plugin_url }}"
     dest: "{{ download_dir }}/es_plugin_moodle.tar.gz"
   become: yes
-  become_user: "{{ansible_user}}"
 
 - name: Ensure unzip is present
   package:
@@ -44,7 +43,6 @@
     dest: "{{ download_dir }}"
     creates: "{{ edu_sharing_plugin_dir }}"
   become: yes
-  become_user: "{{ansible_user}}"
   tags:
     - copy-moodle-es-plugin
 
@@ -253,7 +251,7 @@
       - {name: application_appid, set: moodle_plugin}
       - {name: application_blowfishiv, set: initvect}
       - {name: application_blowfishkey, set: thetestkey}
-      - {name: application_cc_gui_url, set: "http://{{ edu_sharing_base_domain }}:80/edu-sharing/"}
+      - {name: application_cc_gui_url, set: "{{ edu_sharing_base_domain }}:80/edu-sharing/"}
       - {name: application_homerepid, set: "{{ esrepo_appid.matches[0]['entry'] }}"}
       - {name: application_host, set: "{{ moodle_host }}"}
       - {name: application_private_key, set: "{{ moodle_priv_key.stdout }}"}
@@ -276,7 +274,7 @@
       - {name: repository_clientport, set: "{{ esrepo_clientport.matches[0]['entry'] }}"}
       - {name: repository_clientprotocol, set: "{{ esrepo_clientprotocol.matches[0]['entry'] }}"}
       - {name: repository_contenturl, set: "{{ esrepo_contenturl.matches[0]['entry'] }}"}
-      - {name: repository_domain, set: "http://{{ edu_sharing_base_domain }}"}
+      - {name: repository_domain, set: "{{ edu_sharing_base_domain }}"}
       - {name: repository_host, set: "{{ edu_sharing_host }}"}
       - {name: repository_port, set: "{{ esrepo_port.matches[0]['entry'] }}"}
       - {name: repository_protocol, set: "{{  esrepo_protocol.matches[0]['entry'] }}"}
@@ -319,7 +317,6 @@
     chdir: '{{ moodle_root_dir }}/moodle/admin/cli'
   register: attoconfig
 
-# TODO Check if atto config gets set correct
 - name: Edit atto_editor
   command: >-
     sudo -u www-data
@@ -349,11 +346,14 @@
     state: link
   become: yes
 
+  # when working with edu-sharing v4.2 *atto-editor is recommended*
+  # it can be used by setting "texteditors atto,edusharing,tinymce,textarea"
+  # but it can also be activated later in moodle admin area
 - name: Set text editors
   command: >-
     sudo -u www-data
     moosh config-set 
-    texteditors atto,edusharing,tinymce,textarea
+    texteditors edusharing,atto,tinymce,textarea
   args:
     chdir: '{{ moodle_root_dir }}/moodle'
 

--- a/ansible/roles/edu-sharing-plugin/tasks/main.yml
+++ b/ansible/roles/edu-sharing-plugin/tasks/main.yml
@@ -1,39 +1,411 @@
 ---
-  - name: download edu-sharing-plugin sources
-    get_url:
-      url: '{{edusharing_plugin_url}}'
-      dest: "{{download_dir}}/edu-sharing-plugin.tar.gz"
-    tags:
-    - edu-sharing-plugin
+# "{{download_dir}} not base_dir
+- name: Ensure necessary packages are present
+  apt:
+    name: '{{ packages }}'
+    state: present
+  become: yes
+  vars:
+    packages:
+    - python-lxml
+    - unzip
+  tags:
+  - packages
+  - root-task
 
-  - name: extract edu-sharing-plugin sources
-    unarchive:
-      remote_src: yes
-      src: '{{download_dir}}/edu-sharing-plugin.tar.gz'
-      owner: "www-data"
-      group: "www-data"
-      dest: '{{moodle_root_dir}}/moodle'
-      extra_opts: [--strip-components=1]
-    become: yes
-    notify:
-      - restart apache2
-    tags:
-    - root-task
-    - edu-sharing-plugin
+- name: Ensure lxml is installed in pip
+  pip:
+    name: "{{ packages }}"
+    state: present
+  vars:
+    packages:
+      - lxml
+      - pyopenssl
+  become: yes
 
-# Installation via Browser mit Anmeldung, ganz viel Klicki-Bunti => schlecht geskriptet zu lösen
-#  - name: edu-sharing-plugin installation
-#    uri:
-#      url: 'http://{{moodle_host}}/admin/index.php?confirmplugincheck=1&cache=0'
-#
-#  - name: edu-sharing-plugin configuration
-#    uri:
-#      url: 'http://{{moodle_host}}/mod/edusharing/import_metadata.php'
-#      user: "{{ moodle_admin_user }}"
-#      password: "{{ moodle_admin_password }}"
-#      force_basic_auth: yes
-#      method: POST
-#      body_format: form-urlencoded
-#      body:
-#        mdataurl:	http://{{edu-sharing-host}}/edu-sharing/metadata?format=lms
-#
+- name: Download moodle plugin
+  git:
+    repo: https://github.com/edu-sharing/plugin-moodle
+    dest: "{{ download_dir }}/es_plugin_moodle"
+    version: master
+
+- name: Copy blocks folder to Moodle-install-dir
+  copy:
+    remote_src: yes
+    src: "{{ download_dir }}/es_plugin_moodle/blocks"
+    dest: "{{ moodle_root_dir }}/moodle"
+    owner: www-data
+    group: www-data
+    mode: '0775'
+  become: yes
+
+- name: Copy filter folder to Moodle-install-dir
+  copy:
+    remote_src: yes
+    src: "{{ download_dir }}/es_plugin_moodle/filter"
+    dest: "{{ moodle_root_dir }}/moodle"
+    owner: www-data
+    group: www-data
+    mode: '0775'
+  become: yes
+
+- name: Copy lib folder to Moodle-install-dir
+  copy:
+    remote_src: yes
+    src: "{{ download_dir }}/es_plugin_moodle/lib"
+    dest: "{{ moodle_root_dir }}/moodle"
+    owner: www-data
+    group: www-data
+    mode: '0775'
+  become: yes  
+
+- name: Copy mod folder to Moodle-install-dir
+  copy:
+    remote_src: yes
+    src: "{{ download_dir }}/es_plugin_moodle/mod"
+    dest: "{{ moodle_root_dir }}/moodle"
+    owner: www-data
+    group: www-data
+    mode: '0775'
+  become: yes
+  tags:
+  - root-task
+  - edu-sharing-plugin
+
+- name: get esrepo metadata info
+  uri:
+    url: '{{ edu_sharing_url }}/metadata?format=lms'
+    method: GET
+    return_content: yes
+  register: esrepo_meta
+
+- name: Create a private key for moodle-app
+  openssl_privatekey:
+    path: '{{ base_dir }}/moodle.pem'
+    state: present
+
+- name: Read out private key
+  command: 'cat {{ base_dir }}/moodle.pem'
+  register: moodle_priv_key
+  
+
+- name: Create a public key out of generated private key
+  openssl_publickey:
+    privatekey_path: '{{ base_dir }}/moodle.pem'
+    path: '{{ base_dir }}/moodle_pub.pem'
+    state: present
+
+- name: Read out public key
+  command: 'cat {{ base_dir }}/moodle_pub.pem'
+  register: moodle_public_key
+
+- name: get esrepo public key
+  xml:
+    xmlstring: "{{esrepo_meta.content}}"
+    xpath: /properties/entry[@key='public_key']
+    content: 'text'
+  register: esrepo_public_key
+
+- name: get esrepo usagewebservice_wsdl
+  xml:
+    xmlstring: "{{esrepo_meta.content}}"
+    xpath: /properties/entry[@key='usagewebservice_wsdl']
+    content: 'text'
+  register: esrepo_usagewebservice_wsdl
+
+- name: get esrepo type
+  xml:
+    xmlstring: "{{esrepo_meta.content}}"
+    xpath: /properties/entry[@key='type']
+    content: 'text'
+  register: esrepo_type
+
+- name: get esrepo clientport
+  xml:
+    xmlstring: "{{esrepo_meta.content}}"
+    xpath: /properties/entry[@key='clientport']
+    content: 'text'
+  register: esrepo_clientport
+
+- name: get esrepo appcaption
+  xml:
+    xmlstring: "{{esrepo_meta.content}}"
+    xpath: /properties/entry[@key='appcaption']
+    content: 'text'
+  register: esrepo_appcaption
+
+- name: get esrepo protocol
+  xml:
+    xmlstring: "{{esrepo_meta.content}}"
+    xpath: /properties/entry[@key='protocol']
+    content: 'text'
+  register: esrepo_protocol
+
+- name: get esrepo contenturl
+  xml:
+    xmlstring: "{{esrepo_meta.content}}"
+    xpath: /properties/entry[@key='contenturl']
+    content: 'text'
+  register: esrepo_contenturl
+
+- name: get esrepo port
+  xml:
+    xmlstring: "{{esrepo_meta.content}}"
+    xpath: /properties/entry[@key='port']
+    content: 'text'
+  register: esrepo_port
+
+- name: get esrepo appid
+  xml:
+    xmlstring: "{{esrepo_meta.content}}"
+    xpath: /properties/entry[@key='appid']
+    content: 'text'
+  register: esrepo_appid
+
+- name: get esrepo domain
+  xml:
+    xmlstring: "{{esrepo_meta.content}}"
+    xpath: /properties/entry[@key='domain']
+    content: 'text'
+  register: esrepo_domain
+
+- name: get esrepo host
+  xml:
+    xmlstring: "{{esrepo_meta.content}}"
+    xpath: /properties/entry[@key='host']
+    content: 'text'
+  register: esrepo_host
+
+- name: get esrepo authenticationwebservice
+  xml:
+    xmlstring: "{{esrepo_meta.content}}"
+    xpath: /properties/entry[@key='authenticationwebservice']
+    content: 'text'
+  register: esrepo_authenticationwebservice
+
+- name: get esrepo authenticationwebservice_wsdl
+  xml:
+    xmlstring: "{{esrepo_meta.content}}"
+    xpath: /properties/entry[@key='authenticationwebservice_wsdl']
+    content: 'text'
+  register: esrepo_authenticationwebservice_wsdl
+
+- name: get esrepo clientprotocol
+  xml:
+    xmlstring: "{{esrepo_meta.content}}"
+    xpath: /properties/entry[@key='clientprotocol']
+    content: 'text'
+  register: esrepo_clientprotocol
+
+- name: get esrepo usagewebservice
+  xml:
+    xmlstring: "{{esrepo_meta.content}}"
+    xpath: /properties/entry[@key='usagewebservice']
+    content: 'text'
+  register: esrepo_usagewebservice
+
+- name: Register edusharing in moodle
+  vars:
+    esrepo_register_settings:
+      - {name: application_appid, set: moodle_plugin}
+      - {name: application_blowfishiv, set: initvect}
+      - {name: application_blowfishkey, set: initvect}
+      - {name: application_cc_gui_url, set: "{{ edu_sharing_base_domain }}:80/edu-sharing"}
+      - {name: application_homerepid, set: "{{ esrepo_appcaption.matches[0]['entry'] }}"}
+      - {name: application_host, set: "{{ moodle_host }}"}
+      - {name: application_private_key, set: "{{ moodle_priv_key.stdout }}"}
+      - {name: application_public_key, set: "{{ moodle_public_key.stdout }}"}
+      - {name: application_type, set: LMS}
+      - {name: EDU_AUTH_AFFILIATION, set: 'moodle_plugin_{{ moodle_host }}' }
+      - {name: EDU_AUTH_AFFILIATION_NAME, set: 'moodle_plugin_{{ moodle_host }}' }
+      - {name: EDU_AUTH_CONVEYGLOBALGROUPS, set: 0}
+      - {name: EDU_AUTH_KEY, set: username}
+      - {name: EDU_AUTH_PARAM_NAME_EMAIL, set: email}
+      - {name: EDU_AUTH_PARAM_NAME_FIRSTNAME, set: firstname}
+      - {name: EDU_AUTH_PARAM_NAME_LASTNAME, set: lastname}
+      - {name: EDU_AUTH_PARAM_NAME_USERID, set: userid}
+      - {name: edu_guest_guest_id, set: esguest}
+      - {name: edu_guest_option, set: 0}
+      - {name: repository_appcaption, set: "{{esrepo_appcaption.matches[0]['entry'] }}"}
+      - {name: repository_appid, set: "{{esrepo_appid.matches[0]['entry'] }}"}
+      - {name: repository_authenticationwebservice, set: "{{esrepo_authenticationwebservice.matches[0]['entry'] }}"}
+      - {name: repository_authenticationwebservice_wsdl, set: "{{esrepo_authenticationwebservice_wsdl.matches[0]['entry'] }}"}
+      - {name: repository_clientport, set: "{{ esrepo_clientport.matches[0]['entry'] }}"}
+      - {name: repository_clientprotocol, set: "{{ esrepo_clientprotocol.matches[0]['entry'] }}"}
+      - {name: repository_contenturl, set: "{{ esrepo_contenturl.matches[0]['entry'] }}"}
+      - {name: repository_domain, set: "{{ edu_sharing_base_domain }}"}
+      - {name: repository_host, set: "{{ edu_sharing_host }}"}
+      - {name: repository_port, set: "{{ esrepo_port.matches[0]['entry'] }}"}
+      - {name: repository_protocol, set: "{{  esrepo_protocol.matches[0]['entry'] }}"}
+      - {name: repository_public_key, set: "{{ esrepo_public_key.matches[0]['entry'] }}"}
+      - {name: repository_type, set: "{{ esrepo_type.matches[0]['entry'] }}"}
+      - {name: repository_usagewebservice, set: "{{ esrepo_usagewebservice.matches[0]['entry'] }}"}
+      - {name: repository_usagewebservice_wsdl, set: "{{ esrepo_usagewebservice_wsdl.matches[0]['entry'] }}"}
+      # TODO get correct esrepo version
+      - {name: repository_version, set: 4.2}
+  command: >-
+    sudo -u www-data
+    php cfg.php --component=edusharing
+    --name="{{ item.name }}"
+    --set="{{item.set }}"
+  with_items:
+    - "{{esrepo_register_settings}}"
+  args:
+    chdir: '{{ moodle_root_dir }}/moodle/admin/cli'
+  # become: yes
+  # become_user: www-data
+
+# For using atto-editor later, currently still working with edusharing editor
+- name: Copy atto-config
+  template:
+    src: atto-config
+    dest: '{{ moodle_root_dir }}/moodle/admin/cli'
+    owner: www-data
+    group: www-data
+    mode: 0775
+  become: yes
+
+- name: Read atto-config
+  command: cat atto-config
+  args:
+    chdir: '{{ moodle_root_dir }}/moodle/admin/cli'
+  register: attoconfig
+
+# TODO Check if atto config gets set correct
+- name: Edit atto_editor
+  command: >-
+    sudo -u www-data
+    php cfg.php --component=editor_atto --name=toolbar --set="$({{attoconfig.stdout}})"
+  args:
+    chdir: '{{ moodle_root_dir }}/moodle/admin/cli'
+  # become: yes
+  # become_user: www-data
+
+- name: Create moosh folder
+  file:
+    path: "{{ download_dir }}/moosh"
+    state: directory
+    mode: '1755'
+
+- name: Download and unarchive moosh
+  unarchive:
+    src: https://moodle.org/plugins/download.php/19211/moosh_moodle36_2019032200.zip
+    dest: "{{ download_dir }}"
+    owner: vagrant
+    group: vagrant
+    mode: '1775'
+    remote_src: yes
+
+- name: Link moosh.php systemwide
+  file:
+    src: '{{ download_dir }}/moosh/moosh.php'
+    dest: /usr/local/bin/moosh
+    state: link
+  become: yes
+
+- name: Set text editors
+  command: >-
+    sudo -u www-data
+    moosh config-set 
+    texteditors edusharing,atto,tinymce,textarea
+  args:
+    chdir: '{{ moodle_root_dir }}/moodle'
+  # become: yes
+  # become_user: www-data
+
+
+# The problem with the last step of activating the filter is
+# that the moosh filter-set does not work here, because it
+# does not find edusharing. After clicking "Manage Filters" in
+# moodle Admin area the command would work.
+# To circumvent this we set all active filters to -9999 
+# with `moosh filter-set` insert edusharing into the table
+# and then reactivate. This way edusharing also gets sortorder 1
+
+- name: Set filter mathjaxloader to -9999
+  command: >-
+    sudo -u www-data
+    moosh filter-set mathjaxloader -9999
+  args:
+    chdir: '{{ moodle_root_dir }}/moodle'
+  # become: yes
+  # become_user: www-data
+
+- name: Set filter activitynames to -9999
+  command: >-
+    sudo -u www-data
+    moosh filter-set activitynames -9999
+  args:
+    chdir: '{{ moodle_root_dir }}/moodle'
+  # become: yes
+  # become_user: www-data
+
+- name: Set filter mediaplugin to -9999
+  command: >-
+    sudo -u www-data
+    moosh filter-set mediaplugin -9999
+  args:
+    chdir: '{{ moodle_root_dir }}/moodle'
+  # become: yes
+  # become_user: www-data
+
+- name: Query the database to see if edusharing is already enabled
+  command: >-
+    sudo -u www-data
+    moosh sql-run "select * from mdl_filter_active"
+  args:
+    chdir: '{{ moodle_root_dir }}/moodle'
+  # become: yes
+  # become_user: www-data
+  register: mdl_filter_active
+
+- name: Show query result
+  debug:
+    var: mdl_filter_active.stdout
+
+- name: Insert edusharing into mdl_filter_active table
+  command: >-
+    sudo -u www-data
+    moosh sql-run 
+    "insert into mdl_filter_active(id, filter, contextid, active, sortorder) values (4, 'edusharing', 1, 1, 4)"
+  args:
+    chdir: '{{ moodle_root_dir }}/moodle'
+  # become: yes
+  # become_user: www-data
+  when: '"edusharing" not in mdl_filter_active.stdout'
+
+- name: Set filter mathjaxloader to 1
+  command: >-
+    sudo -u www-data
+    moosh filter-set mathjaxloader 1
+  args:
+    chdir: '{{ moodle_root_dir }}/moodle'
+  # become: yes
+  # become_user: www-data
+
+- name: Set filter activitynames to 1
+  command: >-
+    sudo -u www-data
+    moosh filter-set activitynames 1
+  args:
+    chdir: '{{ moodle_root_dir }}/moodle'
+  # become: yes
+  # become_user: www-data
+
+- name: Set filter mediaplugin to 1
+  command: >-
+    sudo -u www-data
+    moosh filter-set mediaplugin 1
+  args:
+    chdir: '{{ moodle_root_dir }}/moodle'
+  # become: yes
+  # become_user: www-data
+
+- name: Upgrade php
+  command: >-
+    sudo -u www-data
+    php upgrade.php --non-interactive
+  args:
+    chdir: '{{ moodle_root_dir }}/moodle/admin/cli'
+  # become: yes
+  # become_user: www-data

--- a/ansible/roles/edu-sharing-plugin/tasks/main.yml
+++ b/ansible/roles/edu-sharing-plugin/tasks/main.yml
@@ -373,26 +373,27 @@
 # with `moosh filter-set` insert edusharing into the table
 # and then reactivate. This way edusharing also gets sortorder 1
 
-- name: Set filter mathjaxloader to -9999
+- name: Select all active filters
   command: >-
     sudo -u www-data
-    moosh filter-set mathjaxloader -9999
+    moosh sql-run 
+    "select filter from mdl_filter_active where active=1 order by sortorder"
   args:
     chdir: '{{ moodle_root_dir }}/moodle'
+  register: active_filters_query_result
 
-- name: Set filter activitynames to -9999
-  command: >-
-    sudo -u www-data
-    moosh filter-set activitynames -9999
-  args:
-    chdir: '{{ moodle_root_dir }}/moodle'
+- set_fact:
+    active_filters: "{{ active_filters_query_result.stdout | regex_findall(regexp,'\\1') }}"
+  vars:
+    regexp: '\[filter\] => (.+)'
 
-- name: Set filter mediaplugin to -9999
+- name: Set active filter to -9999
   command: >-
     sudo -u www-data
-    moosh filter-set mediaplugin -9999
+    moosh filter-set "{{item}}" -9999
   args:
     chdir: '{{ moodle_root_dir }}/moodle'
+  with_items: '{{active_filters}}'
 
 - name: Query the database to see if edusharing is already enabled
   command: >-
@@ -410,31 +411,18 @@
   command: >-
     sudo -u www-data
     moosh sql-run 
-    "insert into mdl_filter_active(id, filter, contextid, active, sortorder) values (4, 'edusharing', 1, 1, 4)"
+    "insert into mdl_filter_active(filter, contextid, active, sortorder) values ('edusharing', 1, 1, 4)"
   args:
     chdir: '{{ moodle_root_dir }}/moodle'
   when: '"edusharing" not in mdl_filter_active.stdout'
 
-- name: Set filter mathjaxloader to 1
+- name: Set active filter to 1
   command: >-
     sudo -u www-data
-    moosh filter-set mathjaxloader 1
+    moosh filter-set "{{item}}" 1
   args:
     chdir: '{{ moodle_root_dir }}/moodle'
-
-- name: Set filter activitynames to 1
-  command: >-
-    sudo -u www-data
-    moosh filter-set activitynames 1
-  args:
-    chdir: '{{ moodle_root_dir }}/moodle'
-
-- name: Set filter mediaplugin to 1
-  command: >-
-    sudo -u www-data
-    moosh filter-set mediaplugin 1
-  args:
-    chdir: '{{ moodle_root_dir }}/moodle'
+  with_items: '{{active_filters}}'
 
 - name: Upgrade php
   command: >-

--- a/ansible/roles/edu-sharing-plugin/tasks/main.yml
+++ b/ansible/roles/edu-sharing-plugin/tasks/main.yml
@@ -245,6 +245,14 @@
     content: 'text'
   register: esrepo_usagewebservice
 
+- name: "get info about esrepo"
+  uri:
+    url: '{{ edu_sharing_url }}/rest/_about'
+    headers:
+      Accept: 'application/json'
+    return_content: yes
+  register: esrepo_about
+
 - name: Register edusharing in moodle
   vars:
     esrepo_register_settings:
@@ -282,8 +290,7 @@
       - {name: repository_type, set: "{{ esrepo_type.matches[0]['entry'] }}"}
       - {name: repository_usagewebservice, set: "{{ esrepo_usagewebservice.matches[0]['entry'] }}"}
       - {name: repository_usagewebservice_wsdl, set: "{{ esrepo_usagewebservice_wsdl.matches[0]['entry'] }}"}
-      # TODO get correct esrepo version
-      - {name: repository_version, set: 4.2}
+      - {name: repository_version, set: "{{ esrepo_about.json.version.repository }}"}
   command: >-
     sudo -u www-data
     php cfg.php --component=edusharing

--- a/ansible/roles/edu-sharing-plugin/tasks/main.yml
+++ b/ansible/roles/edu-sharing-plugin/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-# "{{download_dir}} not base_dir
 - name: Ensure necessary packages are present
   apt:
     name: '{{ packages }}'
@@ -23,54 +22,98 @@
       - pyopenssl
   become: yes
 
-- name: Download moodle plugin
-  git:
-    repo: https://github.com/edu-sharing/plugin-moodle
-    dest: "{{ download_dir }}/es_plugin_moodle"
-    version: master
+- name: download edu-sharing plugin
+  get_url:
+    url: "{{ edusharing_plugin_url }}"
+    dest: "{{ download_dir }}/es_plugin_moodle.tar.gz"
+  become: yes
+  become_user: "{{ansible_user}}"
+
+- name: Ensure unzip is present
+  package:
+    name: ["unzip"]
+  become: yes
+  tags:
+  - packages
+  - root-task
+
+- name: extract edu-sharing-plugin sources
+  unarchive:
+    remote_src: yes
+    src: "{{ download_dir }}/es_plugin_moodle.tar.gz"
+    dest: "{{ download_dir }}"
+    creates: "{{ edu_sharing_plugin_dir }}"
+  become: yes
+  become_user: "{{ansible_user}}"
+  tags:
+    - copy-moodle-es-plugin
 
 - name: Copy blocks folder to Moodle-install-dir
   copy:
     remote_src: yes
-    src: "{{ download_dir }}/es_plugin_moodle/blocks"
+    src: "{{ edu_sharing_plugin_dir }}/blocks"
     dest: "{{ moodle_root_dir }}/moodle"
     owner: www-data
     group: www-data
-    mode: '0775'
+    mode: '1755'
+  tags:
+    - copy-moodle-es-plugin
   become: yes
 
 - name: Copy filter folder to Moodle-install-dir
   copy:
     remote_src: yes
-    src: "{{ download_dir }}/es_plugin_moodle/filter"
+    src: "{{ edu_sharing_plugin_dir }}/filter"
     dest: "{{ moodle_root_dir }}/moodle"
     owner: www-data
     group: www-data
-    mode: '0775'
+    mode: '1755'
+  tags:
+    - copy-moodle-es-plugin
   become: yes
 
+# ISSUE
+# Somehow lib/editor/atto/plugins/edusharing is not copied with copy module
 - name: Copy lib folder to Moodle-install-dir
   copy:
     remote_src: yes
-    src: "{{ download_dir }}/es_plugin_moodle/lib"
+    src: "{{ edu_sharing_plugin_dir }}/lib"
     dest: "{{ moodle_root_dir }}/moodle"
     owner: www-data
     group: www-data
-    mode: '0775'
-  become: yes  
+    mode: '1755'
+    directory_mode: yes
+  tags:
+    - copy-moodle-es-plugin
+  become: yes
+
+- name: Copy lib dir
+  command: >-
+    sudo -u www-data 
+    cp -r 
+    {{ edu_sharing_plugin_dir }}/lib
+    {{ moodle_root_dir }}/moodle
+  args:
+    creates: '{{ moodle_root_dir }}/moodle/lib/editor/atto/plugins/edusharing'
 
 - name: Copy mod folder to Moodle-install-dir
   copy:
     remote_src: yes
-    src: "{{ download_dir }}/es_plugin_moodle/mod"
+    src: "{{ edu_sharing_plugin_dir }}/mod"
     dest: "{{ moodle_root_dir }}/moodle"
     owner: www-data
     group: www-data
-    mode: '0775'
+    mode: '1755'
   become: yes
   tags:
-  - root-task
-  - edu-sharing-plugin
+  - copy-moodle-es-plugin
+
+- name: Upgrade php
+  command: >-
+    sudo -u www-data
+    php upgrade.php --non-interactive
+  args:
+    chdir: '{{ moodle_root_dir }}/moodle/admin/cli'
 
 - name: get esrepo metadata info
   uri:
@@ -209,9 +252,9 @@
     esrepo_register_settings:
       - {name: application_appid, set: moodle_plugin}
       - {name: application_blowfishiv, set: initvect}
-      - {name: application_blowfishkey, set: initvect}
-      - {name: application_cc_gui_url, set: "{{ edu_sharing_base_domain }}:80/edu-sharing"}
-      - {name: application_homerepid, set: "{{ esrepo_appcaption.matches[0]['entry'] }}"}
+      - {name: application_blowfishkey, set: thetestkey}
+      - {name: application_cc_gui_url, set: "http://{{ edu_sharing_base_domain }}:80/edu-sharing/"}
+      - {name: application_homerepid, set: "{{ esrepo_appid.matches[0]['entry'] }}"}
       - {name: application_host, set: "{{ moodle_host }}"}
       - {name: application_private_key, set: "{{ moodle_priv_key.stdout }}"}
       - {name: application_public_key, set: "{{ moodle_public_key.stdout }}"}
@@ -233,7 +276,7 @@
       - {name: repository_clientport, set: "{{ esrepo_clientport.matches[0]['entry'] }}"}
       - {name: repository_clientprotocol, set: "{{ esrepo_clientprotocol.matches[0]['entry'] }}"}
       - {name: repository_contenturl, set: "{{ esrepo_contenturl.matches[0]['entry'] }}"}
-      - {name: repository_domain, set: "{{ edu_sharing_base_domain }}"}
+      - {name: repository_domain, set: "http://{{ edu_sharing_base_domain }}"}
       - {name: repository_host, set: "{{ edu_sharing_host }}"}
       - {name: repository_port, set: "{{ esrepo_port.matches[0]['entry'] }}"}
       - {name: repository_protocol, set: "{{  esrepo_protocol.matches[0]['entry'] }}"}
@@ -252,8 +295,13 @@
     - "{{esrepo_register_settings}}"
   args:
     chdir: '{{ moodle_root_dir }}/moodle/admin/cli'
-  # become: yes
-  # become_user: www-data
+
+- name: Upgrade php
+  command: >-
+    sudo -u www-data
+    php upgrade.php --non-interactive
+  args:
+    chdir: '{{ moodle_root_dir }}/moodle/admin/cli'
 
 # For using atto-editor later, currently still working with edusharing editor
 - name: Copy atto-config
@@ -275,11 +323,9 @@
 - name: Edit atto_editor
   command: >-
     sudo -u www-data
-    php cfg.php --component=editor_atto --name=toolbar --set="$({{attoconfig.stdout}})"
+    php cfg.php --component=editor_atto --name=toolbar --set="{{attoconfig.stdout}}"
   args:
     chdir: '{{ moodle_root_dir }}/moodle/admin/cli'
-  # become: yes
-  # become_user: www-data
 
 - name: Create moosh folder
   file:
@@ -291,8 +337,8 @@
   unarchive:
     src: https://moodle.org/plugins/download.php/19211/moosh_moodle36_2019032200.zip
     dest: "{{ download_dir }}"
-    owner: vagrant
-    group: vagrant
+    owner: '{{ ansible_user }}'
+    group: '{{ ansible_user }}'
     mode: '1775'
     remote_src: yes
 
@@ -307,11 +353,9 @@
   command: >-
     sudo -u www-data
     moosh config-set 
-    texteditors edusharing,atto,tinymce,textarea
+    texteditors atto,edusharing,tinymce,textarea
   args:
     chdir: '{{ moodle_root_dir }}/moodle'
-  # become: yes
-  # become_user: www-data
 
 
 # The problem with the last step of activating the filter is
@@ -328,8 +372,6 @@
     moosh filter-set mathjaxloader -9999
   args:
     chdir: '{{ moodle_root_dir }}/moodle'
-  # become: yes
-  # become_user: www-data
 
 - name: Set filter activitynames to -9999
   command: >-
@@ -337,8 +379,6 @@
     moosh filter-set activitynames -9999
   args:
     chdir: '{{ moodle_root_dir }}/moodle'
-  # become: yes
-  # become_user: www-data
 
 - name: Set filter mediaplugin to -9999
   command: >-
@@ -346,8 +386,6 @@
     moosh filter-set mediaplugin -9999
   args:
     chdir: '{{ moodle_root_dir }}/moodle'
-  # become: yes
-  # become_user: www-data
 
 - name: Query the database to see if edusharing is already enabled
   command: >-
@@ -355,8 +393,6 @@
     moosh sql-run "select * from mdl_filter_active"
   args:
     chdir: '{{ moodle_root_dir }}/moodle'
-  # become: yes
-  # become_user: www-data
   register: mdl_filter_active
 
 - name: Show query result
@@ -370,8 +406,6 @@
     "insert into mdl_filter_active(id, filter, contextid, active, sortorder) values (4, 'edusharing', 1, 1, 4)"
   args:
     chdir: '{{ moodle_root_dir }}/moodle'
-  # become: yes
-  # become_user: www-data
   when: '"edusharing" not in mdl_filter_active.stdout'
 
 - name: Set filter mathjaxloader to 1
@@ -380,8 +414,6 @@
     moosh filter-set mathjaxloader 1
   args:
     chdir: '{{ moodle_root_dir }}/moodle'
-  # become: yes
-  # become_user: www-data
 
 - name: Set filter activitynames to 1
   command: >-
@@ -389,8 +421,6 @@
     moosh filter-set activitynames 1
   args:
     chdir: '{{ moodle_root_dir }}/moodle'
-  # become: yes
-  # become_user: www-data
 
 - name: Set filter mediaplugin to 1
   command: >-
@@ -398,8 +428,6 @@
     moosh filter-set mediaplugin 1
   args:
     chdir: '{{ moodle_root_dir }}/moodle'
-  # become: yes
-  # become_user: www-data
 
 - name: Upgrade php
   command: >-
@@ -407,5 +435,3 @@
     php upgrade.php --non-interactive
   args:
     chdir: '{{ moodle_root_dir }}/moodle/admin/cli'
-  # become: yes
-  # become_user: www-data

--- a/ansible/roles/edu-sharing-plugin/templates/atto-config
+++ b/ansible/roles/edu-sharing-plugin/templates/atto-config
@@ -1,0 +1,13 @@
+collapse = collapse
+style1 = title, bold, italic
+list = unorderedlist, orderedlist
+links = link
+files = image, media, recordrtc, managefiles
+style2 = underline, strike, subscript, superscript
+align = align
+indent = indent
+insert = equation, charmap, table, clear
+edusharing = edusharing
+undo = undo
+accessibility = accessibilitychecker, accessibilityhelper
+other = html

--- a/ansible/roles/moodle/tasks/main.yml
+++ b/ansible/roles/moodle/tasks/main.yml
@@ -60,5 +60,34 @@
   notify:
     - restart apache2
 
+- name: Check if Moodle is installed
+  stat:
+    path: "{{ moodle_root_dir }}/moodle/config.php"
+  register: moodle_installed
+
 - name: moodle Installation
-  shell: "sudo -u www-data /usr/bin/php7.3 {{moodle_root_dir}}/moodle/admin/cli/install.php --non-interactive --agree-license --lang=de --wwwroot={{moodle_url}} --dataroot={{moodle_data_dir}} --dbtype=mariadb --dbhost=localhost --dbname={{moodle_db.name}} --dbuser={{moodle_db.user}} --dbpass={{moodle_db.password}} --dbport={{mariadb_port}} --fullname={{moodle_fullname}} --shortname={{moodle_shortname}} --summary={{moodle_summary}} --adminuser={{moodle_admin_user}} --adminpass={{moodle_admin_password}} --adminemail={{moodle_admin_email}}"
+  shell: >-
+    sudo -u www-data 
+    /usr/bin/php7.3 install.php 
+    --non-interactive 
+    --agree-license 
+    --lang=de 
+    --wwwroot={{moodle_url}} 
+    --dataroot={{moodle_data_dir}} 
+    --dbtype=mariadb 
+    --dbhost=localhost 
+    --dbname={{moodle_db.name}}
+    --dbuser={{moodle_db.user}} 
+    --dbpass={{moodle_db.password}} 
+    --dbport={{mariadb_port}} 
+    --fullname={{moodle_fullname}} 
+    --shortname={{moodle_shortname}} 
+    --summary={{moodle_summary}} 
+    --adminuser={{moodle_admin_user}} 
+    --adminpass={{moodle_admin_password}} 
+    --adminemail={{moodle_admin_email}}
+  args:
+    chdir: "{{moodle_root_dir}}/moodle/admin/cli/"
+  when: not moodle_installed.stat.exists
+  # become: yes
+  # become_user: www-data

--- a/ansible/system.yml
+++ b/ansible/system.yml
@@ -6,6 +6,12 @@
     - mariadb
     - apache
     - moodle
-    - edu-sharing-plugin
   tags:
     - root-task
+
+- hosts: moodle
+  become: yes
+  roles:
+    - edu-sharing-plugin
+  tags:
+    - edu-sharing-plugin


### PR DESCRIPTION
Hallo zusammen,

ich habe die Möglichkeit eingebaut, das Moodle mit einem edu-sharing Repositorium zu verbinden.

Die Implementierung war etwas frickelig und benötigte das moodle-CLI und das Tool "moosh"(https://moosh-online.com/), um sie abschließen zu können (Nummern beziehen sich auf edu-sharing-plugin/tasks/main.yml):

- Zunächst werden die Metadaten aus dem edu-sharing Repo ausgelesen sowie Schlüsselpaare generiert (75-205)

- Anschließend wird das Repo in moodle mit diesen Daten registriert (207-254)

- Konfiguration des Atto-Editors (259-282) (grade wird noch der edu-sharing Editor benutzt, aber kann dann evtl mal auf Atto umgestellt werden)

- Installation und symlinking von moosh (284-304)

- Setzen des Texteditors mit moosh (306-314)

- Setzen des Filters. Hier funktioniert das filter plugin von moosh leider nicht, da vorher scheinbar einmal die filter.php vpn moodle aufgerufen werden muss, ansonsten findet er das edusharing Filter nicht. Als Workaround habe ich den edusharing Eintrag direkt in der Datenbank gemacht (325-411)

Alle anderen Änderungen sind nur Kleinigkeiten.

Liebe Grüße
Steffen
